### PR TITLE
GitHub Actionsをリファクタする

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,30 +1,20 @@
-name: "Unit test"
+name: phpunit
 
-on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
-  phpunit:
+  unit-test:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           tools: composer:v2
-          coverage: none
-          fail-fast: true
-
       - name: Cache Composer dependencies
         uses: actions/cache@v2
         with:
@@ -32,9 +22,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-
       - name: Install dependencies
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
-
       - name: Run PHPUnit
         run: composer phpunit


### PR DESCRIPTION
- ユニットテストにphpunitを利用することを明確化する。
- トリガーをシンプルにする。
- 不要なパラメータや空行を削除する。
- インテグレーションテストではなくユニットテストを実行するjobであることを明確化する。