### PR TITLE
PlantUMLのエラーを解消する

### DIFF
--- a/src/Visitor/AstDiagramCreator.php
+++ b/src/Visitor/AstDiagramCreator.php
@@ -82,7 +82,7 @@ final class AstDiagramCreator extends NodeVisitorAbstract
         $value = $this->value($node);
         fwrite(STDOUT,
             'Object ' . $this->suffixedNodeType($node) . PHP_EOL .
-            ($value === '' ? '' : ($this->suffixedNodeType($node) . ' : ' . $value . PHP_EOL))
+            (preg_replace('/[ 　]/', '', $value) === '' ? '' : $this->suffixedNodeType($node) . ' : ' . $value . PHP_EOL)
         );
     }
 


### PR DESCRIPTION
- ラベルを付与するためのコロンに空白が続くとエラーになるため、空白のみの場合ラベルを付けないようにする。
- 改行コード等は文字列としてラベルに出力する。